### PR TITLE
Add Loki For All Time season cards

### DIFF
--- a/manual_marvelsnap_jhobz/data/cards.json
+++ b/manual_marvelsnap_jhobz/data/cards.json
@@ -19,7 +19,7 @@
 		"id": 2,
 		"defId": "AbsorbingMan",
 		"cost": 4,
-		"power": 5,
+		"power": 4,
 		"name": "Absorbing Man",
 		"description": "<b>On Reveal:</b> If the last card you played has an <b>On Reveal</b>, copy its text. <i>(if it's in play)</i>",
 		"series": 6,
@@ -212,6 +212,30 @@
 		"collectible": true
 	},
 	{
+		"id": 11,
+		"defId": "Annihilus",
+		"cost": 5,
+		"power": 8,
+		"name": "Annihilus",
+		"description": "<b>On Reveal:</b> Your cards with 0 or less Power switch sides. Destroy\nthose that can't.",
+		"attributes": {
+			"data": {
+				"AssignedPower": 0
+			}
+		},
+		"series": 0,
+		"artists": [
+			{
+				"name": "Eduardo Mello",
+				"type": 1
+			},
+			{
+				"name": "Ryan Kinnaird",
+				"type": 4
+			}
+		]
+	},
+	{
 		"id": 12,
 		"defId": "AntMan",
 		"cost": 1,
@@ -400,8 +424,8 @@
 	{
 		"id": 20,
 		"defId": "BlackCat",
-		"cost": 3,
-		"power": 7,
+		"cost": 4,
+		"power": 9,
 		"name": "Black Cat",
 		"description": "If you end the turn with this in your hand, discard it.",
 		"series": 6,
@@ -423,9 +447,25 @@
 		"cost": 1,
 		"power": 2,
 		"name": "Black Knight",
-		"description": "When this is destroyed, draw a card.",
+		"description": "After you discard a card, add the Ebony Blade to your hand with that card's Power. <i>(once per game)</i>",
+		"attributes": {
+			"cards": {
+				"Card_Token": [
+					297
+				]
+			}
+		},
 		"series": 0,
-		"artists": []
+		"artists": [
+			{
+				"name": "Ario Anindito",
+				"type": 1
+			},
+			{
+				"name": "Ryan Kinnaird",
+				"type": 4
+			}
+		]
 	},
 	{
 		"id": 22,
@@ -480,7 +520,7 @@
 		"cost": 1,
 		"power": 3,
 		"name": "Blade",
-		"description": "<b>On Reveal:</b> Discard a card from your hand.",
+		"description": "<b>On Reveal:</b> Discard the rightmost card from your hand.",
 		"series": 4,
 		"artists": [
 			{
@@ -696,7 +736,7 @@
 		"id": 34,
 		"defId": "CaptainMarvel",
 		"cost": 4,
-		"power": 5,
+		"power": 4,
 		"name": "Captain Marvel",
 		"description": "At the end of the game, move to a location that wins you the\ngame. (If possible)",
 		"series": 6,
@@ -1227,7 +1267,7 @@
 		"id": 58,
 		"defId": "DoomBot",
 		"cost": 6,
-		"power": 4,
+		"power": 5,
 		"name": "DoomBot",
 		"description": "<i>\"Doom is supreme!\"</i>",
 		"series": 0,
@@ -1293,7 +1333,7 @@
 		"cost": 6,
 		"power": 5,
 		"name": "Doctor Doom",
-		"description": "<b>On Reveal:</b> Add a 4-Power DoomBot to each other location.",
+		"description": "<b>On Reveal:</b> Add a 5-Power DoomBot to each other location.",
 		"attributes": {
 			"cards": {
 				"Card_Token": [
@@ -1422,13 +1462,13 @@
 	{
 		"id": 67,
 		"defId": "ElsaBloodstone",
-		"cost": 1,
-		"power": 1,
+		"cost": 2,
+		"power": 2,
 		"name": "Elsa Bloodstone",
-		"description": "At the end of each turn, if you are winning this location, +1 Power.",
+		"description": "If you play another card to fill a location, give it +3 Power.",
 		"attributes": {
 			"data": {
-				"AddedPower": 1
+				"AddedPower": 3
 			}
 		},
 		"series": 0,
@@ -1441,7 +1481,8 @@
 				"name": "Ryan Kinnaird",
 				"type": 4
 			}
-		]
+		],
+		"collectible": true
 	},
 	{
 		"id": 68,
@@ -1528,7 +1569,7 @@
 		"id": 72,
 		"defId": "Galactus",
 		"cost": 6,
-		"power": 7,
+		"power": 5,
 		"name": "Galactus",
 		"description": "<b>On Reveal:</b> If you're winning this location and this is your only card here, destroy all other locations.",
 		"series": 8,
@@ -2374,7 +2415,7 @@
 		"id": 112,
 		"defId": "KittyPryde",
 		"cost": 1,
-		"power": 2,
+		"power": 0,
 		"name": "Kitty Pryde",
 		"description": "When this returns to your hand,\n+1 Power. Returns at the start\nof each turn.",
 		"attributes": {
@@ -2476,7 +2517,7 @@
 		"id": 116,
 		"defId": "LadyDeathstrike",
 		"cost": 5,
-		"power": 3,
+		"power": 4,
 		"name": "Lady Deathstrike",
 		"description": "<b>On Reveal:</b> Destroy each card here with less Power than this.",
 		"series": 8,
@@ -2492,7 +2533,7 @@
 		"id": 117,
 		"defId": "LadySif",
 		"cost": 3,
-		"power": 4,
+		"power": 5,
 		"name": "Lady Sif",
 		"description": "<b>On Reveal:</b> Discard the highest-cost card from your hand.",
 		"series": 4,
@@ -2557,7 +2598,7 @@
 		"id": 120,
 		"defId": "Legion",
 		"cost": 5,
-		"power": 8,
+		"power": 7,
 		"name": "Legion",
 		"description": "<b>On Reveal:</b> Replace each other location with this one.",
 		"series": 7,
@@ -2651,7 +2692,7 @@
 				"ReducedCost": 1
 			}
 		},
-		"series": 0,
+		"series": 9,
 		"artists": [
 			{
 				"name": "Ryan Benjamin",
@@ -2661,7 +2702,8 @@
 				"name": "Ryan Kinnaird",
 				"type": 4
 			}
-		]
+		],
+		"collectible": true
 	},
 	{
 		"id": 125,
@@ -3258,10 +3300,10 @@
 	{
 		"id": 151,
 		"defId": "MsMarvel",
-		"cost": 3,
-		"power": 4,
+		"cost": 4,
+		"power": 5,
 		"name": "Ms. Marvel",
-		"description": "<b>Ongoing:</b> If this is your only card here, adjacent locations\nhave +5 Power.",
+		"description": "<b>Ongoing:</b> Adjacent locations where your cards have unique Costs\nhave +5 Power.",
 		"attributes": {
 			"data": {
 				"AddedPower": 5
@@ -3802,7 +3844,7 @@
 		"id": 175,
 		"defId": "Psylocke",
 		"cost": 2,
-		"power": 1,
+		"power": 2,
 		"name": "Psylocke",
 		"description": "<b>On Reveal:</b> Next turn, you get +1 Energy.",
 		"attributes": {
@@ -4087,8 +4129,8 @@
 	{
 		"id": 189,
 		"defId": "Rockslide",
-		"cost": 4,
-		"power": 5,
+		"cost": 3,
+		"power": 3,
 		"name": "Rockslide",
 		"description": "<b>On Reveal:</b> Shuffle 2 Rocks into your opponent's deck.",
 		"attributes": {
@@ -4365,7 +4407,7 @@
 	{
 		"id": 202,
 		"defId": "ShadowKing",
-		"cost": 3,
+		"cost": 2,
 		"power": 3,
 		"name": "Shadow King",
 		"description": "<b>On Reveal:</b> Set all cards here to their original base Power.",
@@ -4540,7 +4582,7 @@
 		"power": 5,
 		"name": "Silver Samurai",
 		"description": "<b>On Reveal:</b> Each player discards the lowest-Power card from their hand.",
-		"series": 0,
+		"series": 8,
 		"artists": [
 			{
 				"name": "Eduardo Mello",
@@ -4550,7 +4592,8 @@
 				"name": "Ryan Kinnaird",
 				"type": 4
 			}
-		]
+		],
+		"collectible": true
 	},
 	{
 		"id": 211,
@@ -4610,7 +4653,7 @@
 		"cost": 1,
 		"power": 2,
 		"name": "Snowguard",
-		"description": "While in your hand, this transforms each turn into a Hawk or a Bear.",
+		"description": "<b>On Reveal:</b> Add the Hawk and Bear auroras to your hand.",
 		"attributes": {
 			"cards": {
 				"Card_Token": [
@@ -4635,9 +4678,9 @@
 	{
 		"id": 214,
 		"defId": "SnowguardBear",
-		"cost": 1,
-		"power": 2,
-		"name": "Snowguard",
+		"cost": 3,
+		"power": 4,
+		"name": "Snowguard Bear",
 		"description": "<b>On Reveal:</b> Trigger the effect of this location.",
 		"attributes": {
 			"cards": {
@@ -4664,10 +4707,10 @@
 	{
 		"id": 215,
 		"defId": "SnowguardHawk",
-		"cost": 1,
-		"power": 2,
-		"name": "Snowguard",
-		"description": "<b>On Reveal:</b> Ignore all location abilities next turn.",
+		"cost": 3,
+		"power": 3,
+		"name": "Snowguard Hawk",
+		"description": "<b>On Reveal:</b> Ignore all location abilities until the end of next turn <i>(or the game)</i>.",
 		"attributes": {
 			"cards": {
 				"Card_Source": [
@@ -4720,7 +4763,7 @@
 		"cost": 1,
 		"power": 1,
 		"name": "Soul Stone",
-		"description": "<b>On Reveal:</b> Draw a card. <b>Ongoing:</b> Enemy cards here have -1 Power.",
+		"description": "<b>Ongoing:</b> Enemy cards here have -1 Power.",
 		"attributes": {
 			"data": {
 				"ReducedPower": 1
@@ -4859,7 +4902,7 @@
 		"id": 224,
 		"defId": "SquirrelGirl",
 		"cost": 1,
-		"power": 1,
+		"power": 2,
 		"name": "Squirrel Girl",
 		"description": "<b>On Reveal:</b> Add a 1-Power Squirrel to each other location.",
 		"attributes": {
@@ -5160,7 +5203,7 @@
 		"id": 237,
 		"defId": "TheCollector",
 		"cost": 2,
-		"power": 2,
+		"power": 0,
 		"name": "The Collector",
 		"description": "When a card enters your hand from anywhere <i>(except your deck)</i>,\n+1 Power.",
 		"attributes": {
@@ -5830,7 +5873,7 @@
 				"AddedEnergy": 1
 			}
 		},
-		"series": 0,
+		"series": 8,
 		"artists": [
 			{
 				"name": "Eduardo Mello",
@@ -6172,13 +6215,13 @@
 		"attributes": {
 			"cards": {
 				"Card_Related": [
-					300,
-					301,
-					302,
-					303,
-					304,
-					305,
-					306
+					307,
+					308,
+					309,
+					310,
+					311,
+					312,
+					313
 				]
 			}
 		},
@@ -6218,10 +6261,10 @@
 	{
 		"id": 287,
 		"defId": "SpiderHam",
-		"cost": 2,
-		"power": 2,
+		"cost": 1,
+		"power": 1,
 		"name": "Spider-Ham",
-		"description": "<b>On Reveal:</b> Transform the highest-cost card in your opponent's hand into a Pig, keeping its Power and Cost.",
+		"description": "<b>On Reveal:</b> Transform the leftmost card in your opponent's hand into a Pig, keeping its Power and Cost.",
 		"attributes": {
 			"cards": {
 				"Card_Token": [
@@ -6322,7 +6365,7 @@
 				]
 			}
 		},
-		"series": 9,
+		"series": 8,
 		"artists": [
 			{
 				"name": "Eduardo Mello",
@@ -6374,7 +6417,7 @@
 				"ReducedCost": 1
 			}
 		},
-		"series": 0,
+		"series": 7,
 		"artists": [
 			{
 				"name": "Eduardo Mello",
@@ -6384,7 +6427,8 @@
 				"name": "Ryan Kinnaird",
 				"type": 4
 			}
-		]
+		],
+		"collectible": true
 	},
 	{
 		"id": 294,
@@ -6393,7 +6437,7 @@
 		"power": 3,
 		"name": "Mobius M. Mobius",
 		"description": "<b>Ongoing:</b> Your Costs can't be increased. Your opponent's Costs can't be reduced.",
-		"series": 0,
+		"series": 7,
 		"artists": [
 			{
 				"name": "Eduardo Mello",
@@ -6403,7 +6447,8 @@
 				"name": "Ryan Kinnaird",
 				"type": 4
 			}
-		]
+		],
+		"collectible": true
 	},
 	{
 		"id": 295,
@@ -6412,6 +6457,34 @@
 		"power": 5,
 		"name": "Alioth",
 		"description": "<b>On Reveal:</b> Destroy ALL enemy cards played here this turn. <i>(including unrevealed cards)</i>",
+		"series": 8,
+		"artists": [
+			{
+				"name": "Eduardo Mello",
+				"type": 1
+			},
+			{
+				"name": "Ryan Kinnaird",
+				"type": 4
+			}
+		],
+		"collectible": true
+	},
+	{
+		"id": 296,
+		"defId": "ManThing",
+		"cost": 4,
+		"power": 5,
+		"name": "Man-Thing",
+		"description": "<b>Ongoing:</b> 1, 2, and 3-Cost cards here have -2 Power.",
+		"attributes": {
+			"data": {
+				"TargetCardCost_1": 1,
+				"TargetCardCost_2": 2,
+				"TargetCardCost_3": 3,
+				"ReducedPower": 2
+			}
+		},
 		"series": 0,
 		"artists": [
 			{
@@ -6425,60 +6498,209 @@
 		]
 	},
 	{
-		"id": 296,
-		"defId": "ManThing",
-		"cost": 4,
-		"power": 6,
-		"name": "Man-Thing",
-		"description": "none",
-		"attributes": {
-			"data": {
-				"TargetCardCost": 3,
-				"ReducedPower": 1
-			}
-		},
-		"series": 0,
-		"artists": []
-	},
-	{
 		"id": 297,
 		"defId": "EbonyBlade",
-		"cost": 5,
-		"power": 4,
+		"cost": 4,
+		"power": 0,
 		"name": "Ebony Blade",
-		"description": "<b>On Reveal:</b> If your Black Knight is here, destroy the highest-Power enemy card(s) here.",
+		"description": "<i>\"The black blade blazes.\"</i>",
 		"attributes": {
 			"cards": {
-				"Card_Modified": [
+				"Card_Source": [
 					21
 				]
 			}
 		},
 		"series": 0,
-		"artists": []
+		"artists": [
+			{
+				"name": "Eduardo Mello",
+				"type": 1
+			},
+			{
+				"name": "Ryan Kinnaird",
+				"type": 4
+			}
+		]
 	},
 	{
 		"id": 298,
 		"defId": "NicoMinoru",
-		"cost": 3,
-		"power": 4,
+		"cost": 1,
+		"power": 2,
 		"name": "Nico Minoru",
-		"description": "none",
+		"description": "<b>On Reveal:</b> After you play your next card, cast a spell. <i>(The spell\nchanges each turn.)</i>",
+		"attributes": {
+			"cards": {
+				"Card_Related": [
+					314,
+					315,
+					316,
+					317,
+					318,
+					319,
+					320
+				]
+			}
+		},
 		"series": 0,
-		"artists": []
+		"artists": [
+			{
+				"name": "Eduardo Mello",
+				"type": 1
+			},
+			{
+				"name": "Ryan Kinnaird",
+				"type": 4
+			}
+		]
 	},
 	{
 		"id": 299,
 		"defId": "WerewolfByNight",
-		"cost": 0,
-		"power": 0,
+		"cost": 3,
+		"power": 3,
 		"name": "Werewolf By Night",
+		"description": "After you play an <b>On Reveal</b> card at another location, move there and\ngain +2 Power.",
+		"attributes": {
+			"data": {
+				"AddedPower": 2
+			}
+		},
+		"series": 0,
+		"artists": [
+			{
+				"name": "Eduardo Mello",
+				"type": 1
+			},
+			{
+				"name": "Ryan Kinnaird",
+				"type": 4
+			}
+		]
+	},
+	{
+		"id": 300,
+		"defId": "Gladiator",
+		"cost": 3,
+		"power": 8,
+		"name": "Gladiator",
+		"description": "<b>On Reveal:</b> Add a card from your opponent's deck to their side of this location. If it has less Power, destroy it.",
+		"series": 0,
+		"artists": [
+			{
+				"name": "Eduardo Mello",
+				"type": 1
+			},
+			{
+				"name": "Ryan Kinnaird",
+				"type": 4
+			}
+		]
+	},
+	{
+		"id": 301,
+		"defId": "Martyr",
+		"cost": 2,
+		"power": 6,
+		"name": "Martyr",
+		"description": "At the end of the game, move to a location that LOSES you the\ngame. <i>(if possible)</i>",
+		"series": 0,
+		"artists": [
+			{
+				"name": "Eduardo Mello",
+				"type": 1
+			},
+			{
+				"name": "Ryan Kinnaird",
+				"type": 4
+			}
+		]
+	},
+	{
+		"id": 302,
+		"defId": "Djinn",
+		"cost": 0,
+		"power": 1,
+		"name": "Djinn",
+		"description": "<b>On Reveal:</b> Next turn, you get +2 Energy.",
+		"attributes": {
+			"data": {
+				"AddedEnergy": 2
+			}
+		},
+		"series": 0,
+		"artists": []
+	},
+	{
+		"id": 303,
+		"defId": "SebastianShaw",
+		"cost": 1,
+		"power": 1,
+		"name": "Sebastian Shaw",
 		"description": "none",
 		"series": 0,
 		"artists": []
 	},
 	{
-		"id": 300,
+		"id": 304,
+		"defId": "Firestar",
+		"cost": 1,
+		"power": 2,
+		"name": "Firestar",
+		"description": "none",
+		"series": 0,
+		"artists": [
+			{
+				"name": "Joverine",
+				"type": 1
+			},
+			{
+				"name": "Ryan Kinnaird",
+				"type": 4
+			}
+		]
+	},
+	{
+		"id": 305,
+		"defId": "Havok",
+		"cost": 1,
+		"power": 2,
+		"name": "Havok",
+		"description": "none",
+		"series": 0,
+		"artists": [
+			{
+				"name": "Joverine",
+				"type": 1
+			},
+			{
+				"name": "Ryan Kinnaird",
+				"type": 4
+			}
+		]
+	},
+	{
+		"id": 306,
+		"defId": "Selene",
+		"cost": 1,
+		"power": 2,
+		"name": "Selene",
+		"description": "none",
+		"series": 0,
+		"artists": [
+			{
+				"name": "Joverine",
+				"type": 1
+			},
+			{
+				"name": "Ryan Kinnaird",
+				"type": 4
+			}
+		]
+	},
+	{
+		"id": 307,
 		"defId": "EvolvedWasp",
 		"cost": 0,
 		"power": 1,
@@ -6493,7 +6715,7 @@
 		"artists": []
 	},
 	{
-		"id": 301,
+		"id": 308,
 		"defId": "EvolvedMistyKnight",
 		"cost": 1,
 		"power": 2,
@@ -6508,7 +6730,7 @@
 		"artists": []
 	},
 	{
-		"id": 302,
+		"id": 309,
 		"defId": "EvolvedShocker",
 		"cost": 2,
 		"power": 3,
@@ -6523,7 +6745,7 @@
 		"artists": []
 	},
 	{
-		"id": 303,
+		"id": 310,
 		"defId": "EvolvedCyclops",
 		"cost": 3,
 		"power": 4,
@@ -6539,7 +6761,7 @@
 		"artists": []
 	},
 	{
-		"id": 304,
+		"id": 311,
 		"defId": "EvolvedTheThing",
 		"cost": 4,
 		"power": 6,
@@ -6555,7 +6777,7 @@
 		"artists": []
 	},
 	{
-		"id": 305,
+		"id": 312,
 		"defId": "EvolvedAbomination",
 		"cost": 5,
 		"power": 9,
@@ -6570,7 +6792,7 @@
 		"artists": []
 	},
 	{
-		"id": 306,
+		"id": 313,
 		"defId": "EvolvedHulk",
 		"cost": 6,
 		"power": 12,
@@ -6579,6 +6801,166 @@
 		"attributes": {
 			"data": {
 				"AddedPower": 2
+			}
+		},
+		"series": 0,
+		"artists": []
+	},
+	{
+		"id": 314,
+		"defId": "Spell01NicoMinoru",
+		"cost": 1,
+		"power": 2,
+		"name": "Nico Minoru",
+		"description": "<b>On Reveal:</b> After you play your next card, it becomes a Demon.",
+		"attributes": {
+			"cards": {
+				"Card_Token": [
+					52
+				],
+				"Card_Related": [
+					315,
+					316,
+					317,
+					318,
+					319,
+					320
+				]
+			}
+		},
+		"series": 0,
+		"artists": []
+	},
+	{
+		"id": 315,
+		"defId": "Spell02NicoMinoru",
+		"cost": 1,
+		"power": 2,
+		"name": "Nico Minoru",
+		"description": "<b>On Reveal:</b> After you play your next card, destroy it and draw two cards.",
+		"attributes": {
+			"cards": {
+				"Card_Related": [
+					314,
+					316,
+					317,
+					318,
+					319,
+					320
+				]
+			}
+		},
+		"series": 0,
+		"artists": []
+	},
+	{
+		"id": 316,
+		"defId": "Spell03NicoMinoru",
+		"cost": 1,
+		"power": 2,
+		"name": "Nico Minoru",
+		"description": "<b>On Reveal:</b> After you play your next card, move it one location to the right.",
+		"attributes": {
+			"cards": {
+				"Card_Related": [
+					314,
+					315,
+					317,
+					318,
+					319,
+					320
+				]
+			}
+		},
+		"series": 0,
+		"artists": []
+	},
+	{
+		"id": 317,
+		"defId": "Spell04NicoMinoru",
+		"cost": 1,
+		"power": 2,
+		"name": "Nico Minoru",
+		"description": "<b>On Reveal:</b> After you play your next card, give it +2 Power.",
+		"attributes": {
+			"data": {
+				"AddedPower": 2
+			},
+			"cards": {
+				"Card_Related": [
+					314,
+					315,
+					316,
+					318,
+					319,
+					320
+				]
+			}
+		},
+		"series": 0,
+		"artists": []
+	},
+	{
+		"id": 318,
+		"defId": "Spell05NicoMinoru",
+		"cost": 1,
+		"power": 2,
+		"name": "Nico Minoru",
+		"description": "<b>On Reveal:</b> After you play your next card, replace that card's location.",
+		"attributes": {
+			"cards": {
+				"Card_Related": [
+					314,
+					315,
+					316,
+					317,
+					319,
+					320
+				]
+			}
+		},
+		"series": 0,
+		"artists": []
+	},
+	{
+		"id": 319,
+		"defId": "Spell06NicoMinoru",
+		"cost": 1,
+		"power": 2,
+		"name": "Nico Minoru",
+		"description": "<b>On Reveal:</b> After you play your next card, add a copy of it to your hand.",
+		"attributes": {
+			"cards": {
+				"Card_Related": [
+					314,
+					315,
+					316,
+					317,
+					318,
+					320
+				]
+			}
+		},
+		"series": 0,
+		"artists": []
+	},
+	{
+		"id": 320,
+		"defId": "Spell07NicoMinoru",
+		"cost": 1,
+		"power": 2,
+		"name": "Nico Minoru",
+		"description": "<b>On Reveal:</b> After you play your next card, double this card's Power.",
+		"attributes": {
+			"cards": {
+				"Card_Related": [
+					314,
+					315,
+					316,
+					317,
+					318,
+					319
+				]
 			}
 		},
 		"series": 0,

--- a/manual_marvelsnap_jhobz/data/items.json
+++ b/manual_marvelsnap_jhobz/data/items.json
@@ -3,7 +3,8 @@
         "name": "Abomination",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -11,7 +12,8 @@
         "name": "Absorbing Man",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -19,7 +21,8 @@
         "name": "Adam Warlock",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -27,7 +30,8 @@
         "name": "Aero",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -35,7 +39,8 @@
         "name": "Agatha Harkness",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -43,7 +48,8 @@
         "name": "Agent 13",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -51,7 +57,8 @@
         "name": "Agent Coulson",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -59,7 +66,8 @@
         "name": "America Chavez",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -67,7 +75,8 @@
         "name": "Angel",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -75,7 +84,8 @@
         "name": "Angela",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -83,7 +93,8 @@
         "name": "Ant Man",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -91,7 +102,8 @@
         "name": "Apocalypse",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -99,7 +111,8 @@
         "name": "Armor",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -107,7 +120,8 @@
         "name": "Arnim Zola",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -115,7 +129,8 @@
         "name": "Baron Mordo",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -123,7 +138,8 @@
         "name": "Beast",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -131,7 +147,8 @@
         "name": "Bishop",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -139,7 +156,8 @@
         "name": "Black Bolt",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -147,7 +165,8 @@
         "name": "Black Cat",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -155,7 +174,8 @@
         "name": "Black Panther",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -163,7 +183,8 @@
         "name": "Black Widow",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -171,7 +192,8 @@
         "name": "Blade",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -179,7 +201,8 @@
         "name": "Blue Marvel",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -187,7 +210,8 @@
         "name": "Brood",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -195,7 +219,8 @@
         "name": "Bucky Barnes",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -203,7 +228,8 @@
         "name": "Cable",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -211,7 +237,8 @@
         "name": "Captain America",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -219,7 +246,8 @@
         "name": "Captain Marvel",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -227,7 +255,8 @@
         "name": "Carnage",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -235,7 +264,8 @@
         "name": "Cerebro",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -243,7 +273,8 @@
         "name": "Cloak",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -251,7 +282,8 @@
         "name": "Colleen Wing",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -259,7 +291,8 @@
         "name": "Colossus",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -267,7 +300,8 @@
         "name": "Cosmo",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -275,7 +309,8 @@
         "name": "Crossbones",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -283,7 +318,8 @@
         "name": "Crystal",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -291,7 +327,8 @@
         "name": "Cyclops",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -299,7 +336,8 @@
         "name": "Dagger",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -307,7 +345,8 @@
         "name": "Daredevil",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -315,7 +354,8 @@
         "name": "Darkhawk",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -323,7 +363,8 @@
         "name": "Dazzler",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -331,7 +372,8 @@
         "name": "Deadpool",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -339,7 +381,8 @@
         "name": "Death",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -347,7 +390,8 @@
         "name": "Deathlok",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -355,7 +399,8 @@
         "name": "Debrii",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -363,7 +408,8 @@
         "name": "Destroyer",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -371,7 +417,8 @@
         "name": "Devil Dinosaur",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -379,7 +426,8 @@
         "name": "Doctor Octopus",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -387,7 +435,8 @@
         "name": "Doctor Strange",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -395,7 +444,8 @@
         "name": "Domino",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -403,7 +453,8 @@
         "name": "Dracula",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -411,7 +462,8 @@
         "name": "Drax",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -419,7 +471,8 @@
         "name": "Doctor Doom",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -427,7 +480,8 @@
         "name": "Ebony Maw",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -435,7 +489,8 @@
         "name": "Electro",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -443,7 +498,8 @@
         "name": "Elektra",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -451,7 +507,8 @@
         "name": "Enchantress",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -459,7 +516,8 @@
         "name": "Falcon",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -467,7 +525,8 @@
         "name": "Forge",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -475,7 +534,8 @@
         "name": "Galactus",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -483,7 +543,8 @@
         "name": "Gambit",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -491,7 +552,8 @@
         "name": "Gamora",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -499,7 +561,8 @@
         "name": "Ghost Rider",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -507,7 +570,8 @@
         "name": "Ghost-Spider",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -515,7 +579,8 @@
         "name": "Giganto",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -523,7 +588,8 @@
         "name": "Goose",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -531,7 +597,8 @@
         "name": "Green Goblin",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -539,7 +606,8 @@
         "name": "Groot",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -547,7 +615,8 @@
         "name": "Hawkeye",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -555,7 +624,8 @@
         "name": "Hazmat",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -563,7 +633,8 @@
         "name": "Heimdall",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -571,7 +642,8 @@
         "name": "Hela",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -579,7 +651,8 @@
         "name": "Helicarrier",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -587,7 +660,8 @@
         "name": "Hellcow",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -595,7 +669,8 @@
         "name": "Hit-Monkey",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -603,7 +678,8 @@
         "name": "Hobgoblin",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -611,7 +687,8 @@
         "name": "The Hood",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -619,7 +696,8 @@
         "name": "Hulk",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -627,7 +705,8 @@
         "name": "Hulkbuster",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -635,7 +714,8 @@
         "name": "Human Torch",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -643,7 +723,8 @@
         "name": "Iceman",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -651,7 +732,8 @@
         "name": "The Infinaut",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -659,7 +741,8 @@
         "name": "Invisible Woman",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -667,7 +750,8 @@
         "name": "Iron Fist",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -675,7 +759,8 @@
         "name": "Ironheart",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -683,7 +768,8 @@
         "name": "Iron Man",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -691,7 +777,8 @@
         "name": "Jane Foster Mighty Thor",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -699,7 +786,8 @@
         "name": "Jean Grey",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -707,7 +795,8 @@
         "name": "Jeff the Baby Land Shark",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -715,7 +804,8 @@
         "name": "Jessica Jones",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -723,7 +813,8 @@
         "name": "Jubilee",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -731,7 +822,8 @@
         "name": "Juggernaut",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -739,7 +831,8 @@
         "name": "Kang",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -747,7 +840,8 @@
         "name": "Ka-Zar",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -755,7 +849,8 @@
         "name": "Killmonger",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -763,7 +858,8 @@
         "name": "Kingpin",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -771,7 +867,8 @@
         "name": "Kitty Pryde",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -779,7 +876,8 @@
         "name": "Klaw",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -787,7 +885,8 @@
         "name": "Korg",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -795,7 +894,8 @@
         "name": "Kraven",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -803,7 +903,8 @@
         "name": "Lady Deathstrike",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -811,7 +912,8 @@
         "name": "Lady Sif",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -819,7 +921,8 @@
         "name": "Leader",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -827,7 +930,8 @@
         "name": "Leech",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -835,7 +939,8 @@
         "name": "Legion",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -843,7 +948,8 @@
         "name": "The Living Tribunal",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -851,7 +957,8 @@
         "name": "Lizard",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -859,7 +966,17 @@
         "name": "Lockjaw",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
+        ],
+        "progression": true
+    },
+    {
+        "name": "Loki",
+        "count": 1,
+        "category": [
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -867,7 +984,8 @@
         "name": "Luke Cage",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -875,7 +993,8 @@
         "name": "Magik",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -883,7 +1002,8 @@
         "name": "Magneto",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -891,7 +1011,8 @@
         "name": "Mantis",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -899,7 +1020,8 @@
         "name": "Maria Hill",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -907,7 +1029,8 @@
         "name": "Master Mold",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -915,7 +1038,8 @@
         "name": "Maximus",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -923,7 +1047,8 @@
         "name": "M'Baku",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -931,7 +1056,8 @@
         "name": "Medusa",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -939,7 +1065,8 @@
         "name": "Miles Morales",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -947,7 +1074,8 @@
         "name": "Mirage",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -955,7 +1083,8 @@
         "name": "Misty Knight",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -963,7 +1092,8 @@
         "name": "M.O.D.O.K.",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -971,7 +1101,8 @@
         "name": "Mojo",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -979,7 +1110,8 @@
         "name": "Moon Girl",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -987,7 +1119,8 @@
         "name": "Moon Knight",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -995,7 +1128,8 @@
         "name": "Morbius",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1003,7 +1137,8 @@
         "name": "Morph",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1011,7 +1146,8 @@
         "name": "Mister Fantastic",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1019,7 +1155,8 @@
         "name": "Mister Negative",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1027,7 +1164,8 @@
         "name": "Mister Sinister",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1035,7 +1173,8 @@
         "name": "Multiple Man",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1043,7 +1182,8 @@
         "name": "Mysterio",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1051,7 +1191,8 @@
         "name": "Mystique",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1059,7 +1200,8 @@
         "name": "Nakia",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1067,7 +1209,8 @@
         "name": "Namor",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1075,7 +1218,8 @@
         "name": "Nebula",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1083,7 +1227,8 @@
         "name": "Negasonic Teenage Warhead",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1091,7 +1236,8 @@
         "name": "Nick Fury",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1099,7 +1245,8 @@
         "name": "Nightcrawler",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1107,7 +1254,8 @@
         "name": "Nova",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1115,7 +1263,8 @@
         "name": "Odin",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -1123,7 +1272,8 @@
         "name": "Okoye",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1131,7 +1281,8 @@
         "name": "Omega Red",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1139,7 +1290,8 @@
         "name": "Onslaught",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -1147,7 +1299,8 @@
         "name": "Orka",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -1155,7 +1308,8 @@
         "name": "Patriot",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1163,7 +1317,8 @@
         "name": "Polaris",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1171,7 +1326,8 @@
         "name": "Professor X",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1179,7 +1335,8 @@
         "name": "Psylocke",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1187,7 +1344,8 @@
         "name": "Punisher",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1195,7 +1353,8 @@
         "name": "Quake",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1203,7 +1362,8 @@
         "name": "Quicksilver",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1211,7 +1371,8 @@
         "name": "Quinjet",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1219,7 +1380,8 @@
         "name": "Red Skull",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1227,7 +1389,8 @@
         "name": "Rescue",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1235,7 +1398,8 @@
         "name": "Rhino",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1243,7 +1407,8 @@
         "name": "Rocket Raccoon",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1251,7 +1416,8 @@
         "name": "Rockslide",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1259,7 +1425,8 @@
         "name": "Rogue",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1267,7 +1434,8 @@
         "name": "Ronan the Accuser",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1275,7 +1443,8 @@
         "name": "Sabretooth",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1283,7 +1452,8 @@
         "name": "Sandman",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1291,7 +1461,8 @@
         "name": "Sauron",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1299,7 +1470,8 @@
         "name": "Scarlet Witch",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1307,7 +1479,8 @@
         "name": "Scorpion",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1315,7 +1488,8 @@
         "name": "Sentinel",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1323,7 +1497,8 @@
         "name": "Sentry",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1331,7 +1506,8 @@
         "name": "Sera",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1339,7 +1515,8 @@
         "name": "Shadow King",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1347,7 +1524,8 @@
         "name": "Shang-Chi",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1355,7 +1533,8 @@
         "name": "Shanna",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1363,7 +1542,8 @@
         "name": "She-Hulk",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -1371,7 +1551,8 @@
         "name": "Shocker",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1379,7 +1560,8 @@
         "name": "Shuri",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1387,7 +1569,17 @@
         "name": "Silk",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
+        ],
+        "progression": true
+    },
+    {
+        "name": "Silver Samurai",
+        "count": 1,
+        "category": [
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1395,7 +1587,8 @@
         "name": "Silver Surfer",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1403,7 +1596,8 @@
         "name": "Snowguard",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1411,7 +1605,8 @@
         "name": "Spectrum",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -1419,7 +1614,8 @@
         "name": "Spider-Man",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1427,7 +1623,8 @@
         "name": "Spider-Woman",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1435,7 +1632,8 @@
         "name": "Squirrel Girl",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1443,7 +1641,8 @@
         "name": "Star-Lord",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1451,7 +1650,8 @@
         "name": "Storm",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1459,7 +1659,8 @@
         "name": "Strong Guy",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1467,7 +1668,8 @@
         "name": "Sunspot",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1475,7 +1677,8 @@
         "name": "Super-Skrull",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1483,7 +1686,8 @@
         "name": "Swarm",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1491,7 +1695,8 @@
         "name": "Sword Master",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1499,7 +1704,8 @@
         "name": "Taskmaster",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1507,7 +1713,8 @@
         "name": "Thanos",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -1515,7 +1722,8 @@
         "name": "The Collector",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1523,7 +1731,8 @@
         "name": "Phoenix Force",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1531,7 +1740,8 @@
         "name": "The Thing",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1539,7 +1749,8 @@
         "name": "Thor",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1547,7 +1758,8 @@
         "name": "Titania",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1555,7 +1767,8 @@
         "name": "Typhoid Mary",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1563,7 +1776,8 @@
         "name": "Uatu the Watcher",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1571,7 +1785,8 @@
         "name": "Ultron",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -1579,7 +1794,8 @@
         "name": "Valkyrie",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1587,7 +1803,8 @@
         "name": "Venom",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1595,7 +1812,8 @@
         "name": "Viper",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1603,7 +1821,8 @@
         "name": "Vision",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1611,7 +1830,8 @@
         "name": "Vulture",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1619,7 +1839,8 @@
         "name": "Warpath",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1627,7 +1848,8 @@
         "name": "Wasp",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1635,7 +1857,8 @@
         "name": "Wave",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1643,7 +1866,8 @@
         "name": "White Queen",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1651,7 +1875,8 @@
         "name": "White Tiger",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1659,7 +1884,8 @@
         "name": "Wolfsbane",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
         ],
         "progression": true
     },
@@ -1667,7 +1893,8 @@
         "name": "Wolverine",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1675,7 +1902,8 @@
         "name": "Wong",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1683,7 +1911,8 @@
         "name": "X-23",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1691,7 +1920,8 @@
         "name": "Yellowjacket",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1699,7 +1929,8 @@
         "name": "Yondu",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1707,7 +1938,8 @@
         "name": "Zabu",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "2 Cost Cards"
         ],
         "progression": true
     },
@@ -1715,7 +1947,8 @@
         "name": "Zero",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1723,7 +1956,8 @@
         "name": "Bast",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1731,7 +1965,8 @@
         "name": "Attuma",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1739,7 +1974,8 @@
         "name": "Knull",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     },
@@ -1747,7 +1983,8 @@
         "name": "Stature",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1755,7 +1992,8 @@
         "name": "Ghost",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1763,7 +2001,8 @@
         "name": "Nimrod",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "5 Cost Cards"
         ],
         "progression": true
     },
@@ -1771,7 +2010,8 @@
         "name": "Stegron",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1779,7 +2019,8 @@
         "name": "Howard the Duck",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1787,7 +2028,8 @@
         "name": "High Evolutionary",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1795,7 +2037,8 @@
         "name": "Iron Lad",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1803,7 +2046,8 @@
         "name": "Spider-Ham",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1811,7 +2055,8 @@
         "name": "Spider-Man 2099",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "4 Cost Cards"
         ],
         "progression": true
     },
@@ -1819,7 +2064,8 @@
         "name": "Echo",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "0-1 Cost Cards"
         ],
         "progression": true
     },
@@ -1827,7 +2073,35 @@
         "name": "Daken",
         "count": 1,
         "category": [
-            "Cards"
+            "Cards",
+            "3 Cost Cards"
+        ],
+        "progression": true
+    },
+    {
+        "name": "Ravonna Renslayer",
+        "count": 1,
+        "category": [
+            "Cards",
+            "3 Cost Cards"
+        ],
+        "progression": true
+    },
+    {
+        "name": "Mobius M. Mobius",
+        "count": 1,
+        "category": [
+            "Cards",
+            "2 Cost Cards"
+        ],
+        "progression": true
+    },
+    {
+        "name": "Alioth",
+        "count": 1,
+        "category": [
+            "Cards",
+            "6+ Cost Cards"
         ],
         "progression": true
     }

--- a/manual_marvelsnap_jhobz/scripts/convert_cards.mjs
+++ b/manual_marvelsnap_jhobz/scripts/convert_cards.mjs
@@ -11,7 +11,7 @@ const convertCards = (from, to) => {
             progression: true
         }))
     try {
-        fs.writeFileSync('out.json', JSON.stringify(items))
+        fs.writeFileSync(to, JSON.stringify(items))
         console.log('Successfully converted cards')
     } catch (e) {
         console.error('Something went wrong', e)
@@ -20,4 +20,4 @@ const convertCards = (from, to) => {
     return 0
 }
 
-convertCards('../data/cards.json', 'out.json')
+convertCards('../data/cards.json', '../data/items.json')

--- a/manual_marvelsnap_jhobz/scripts/convert_cards.mjs
+++ b/manual_marvelsnap_jhobz/scripts/convert_cards.mjs
@@ -3,7 +3,13 @@ import fs from 'fs'
 const convertCards = (from, to) => {
     const infile = fs.readFileSync(from, 'utf8')
     const cards = JSON.parse(infile)
-    const items = cards.filter(({ collectible }) => collectible).map(({ name }) => ({ name, count: 1, category: ["Cards"], progression: true }))
+    const items = cards.filter(({ series, collectible }) => collectible && series).map(({ name, cost }) => (
+        {
+            name,
+            count: 1,
+            category: ["Cards", `${(cost <= 1 ? "0-1" : (cost >= 6 ? "6+" : cost))} Cost Cards`],
+            progression: true
+        }))
     try {
         fs.writeFileSync('out.json', JSON.stringify(items))
         console.log('Successfully converted cards')


### PR DESCRIPTION
Changes:
* Adds new cards from September (Loki) season
* Adds energy cost categories to cards for easier filtering
* Fixes card import script writing to wrong file
* Fixes card import script including some unreleased (upcoming) cards